### PR TITLE
Add IbClientAdapter#ib_client_connected?

### DIFF
--- a/lib/ib_ruby_proxy/server/ib_client_adapter.rb
+++ b/lib/ib_ruby_proxy/server/ib_client_adapter.rb
@@ -26,6 +26,10 @@ module IbRubyProxy
         @ib_wrapper_adapter = ib_wrapper_adapter
       end
 
+      def ib_client_connected?
+        @ib_client.isConnected
+      end
+
       # @param [IbRubyProxy::Client::IbCallbacksObserver] ib_callbacks_observer
       def add_ib_callbacks_observer(ib_callbacks_observer)
         ib_wrapper_adapter.add_observer(ib_callbacks_observer)

--- a/lib/ib_ruby_proxy/server/ib_proxy_service.rb
+++ b/lib/ib_ruby_proxy/server/ib_proxy_service.rb
@@ -20,9 +20,9 @@ module IbRubyProxy
     # * Starts an IB message-processing thread that will dispatch messages sent to IB client app (
     #   gateway or TWS)
     class IbProxyService
-      DEFAULT_IB_HOST = 'localhost'
+      DEFAULT_IB_HOST = 'localhost'.freeze
       DEFAULT_IB_GATEWAY_PORT = 4002
-      DEFAULT_DRB_HOST = 'localhost'
+      DEFAULT_DRB_HOST = 'localhost'.freeze
       DEFAULT_DRB_PORT = 1992
 
       # @param [String] ib_host Hostname for the IB client app (gateway or TWS). Default +localhost+


### PR DESCRIPTION
This method returns the status of the client. It can be used like so:

```ruby
DRbObject.new_with_uri("druby://localhost:1992").ib_client_connected?
```

This is useful for liveness probes and health checks when running in a production system.