### PR TITLE
Add adjustable verbosity for server DRb

### DIFF
--- a/bin/ibproxy
+++ b/bin/ibproxy
@@ -23,6 +23,7 @@ command :server do |c|
   c.option '--ib-port PORT', Integer, "Port for interactive brokers client. #{IbRubyProxy::Server::IbProxyService::DEFAULT_IB_GATEWAY_PORT} by default (Gateway). Default for TWS is whatever"
   c.option '--drb-host HOST', String, "Host for the server drb endpoint. #{IbRubyProxy::Server::IbProxyService::DEFAULT_DRB_HOST} by default"
   c.option '--drb-port PORT', Integer, "Port for the served drb endpoint. #{IbRubyProxy::Server::IbProxyService::DEFAULT_DRB_PORT} by default"
+  c.option '--verbose-server BOOL', String, "Bool for server verbosity. #{IbRubyProxy::Server::IbProxyService::DEFAULT_SERVER_VERBOSITY} by default"
 
   c.action do |args, options|
     options.default(
@@ -30,16 +31,22 @@ command :server do |c|
       ib_port: IbRubyProxy::Server::IbProxyService::DEFAULT_IB_GATEWAY_PORT,
       drb_host: IbRubyProxy::Server::IbProxyService::DEFAULT_DRB_HOST,
       drb_port: IbRubyProxy::Server::IbProxyService::DEFAULT_DRB_PORT,
+      verbose_server: IbRubyProxy::Server::IbProxyService::DEFAULT_SERVER_VERBOSITY,
     )
 
     ib_host = options.ib_host
     ib_port = options.ib_port
     drb_host = options.drb_host
     drb_port = options.drb_port
+    verbose_server = options.verbose_server
 
     puts "Starting with ib port #{ib_port} and drb port #{drb_port}..."
     IbRubyProxy::Server::IbProxyService.new(
-      ib_host: ib_host, ib_port: ib_port, drb_host: drb_host, drb_port: drb_port
+      ib_host: ib_host,
+      ib_port: ib_port,
+      drb_host: drb_host,
+      drb_port: drb_port,
+      verbose_server: verbose_server
     ).start
   end
 end

--- a/lib/ib_ruby_proxy/server/ib_proxy_service.rb
+++ b/lib/ib_ruby_proxy/server/ib_proxy_service.rb
@@ -24,17 +24,21 @@ module IbRubyProxy
       DEFAULT_IB_GATEWAY_PORT = 4002
       DEFAULT_DRB_HOST = 'localhost'.freeze
       DEFAULT_DRB_PORT = 1992
+      DEFAULT_SERVER_VERBOSITY = 'true'.freeze
 
       # @param [String] ib_host Hostname for the IB client app (gateway or TWS). Default +localhost+
       # @param [Integer] ib_port Port for hte IB client app (gateway or TWS). Default +4002+ (gateway)
       # @param [String] drb_host Hostname for the DRB process. Default +localhost+
       # @param [Integer] drb_port Port for the . Default +1992+
+      # @param [String] verbose_server true/false for server verbosity . Default +true+
       def initialize(ib_host: DEFAULT_IB_HOST, ib_port: DEFAULT_IB_GATEWAY_PORT,
-                     drb_host: DEFAULT_DRB_HOST, drb_port: DEFAULT_DRB_PORT)
+                     drb_host: DEFAULT_DRB_HOST, drb_port: DEFAULT_DRB_PORT,
+                     verbose_server: DEFAULT_SERVER_VERBOSITY)
         @ib_host = ib_host
         @ib_port = ib_port
         @drb_host = drb_host
         @drb_port = drb_port
+        @verbose_server = { 'true' => true, 'false' => false }.fetch(verbose_server, true)
 
         @wrapper = IbRubyProxy::Server::IbWrapperAdapter.new
         @client = wrapper.client
@@ -48,7 +52,7 @@ module IbRubyProxy
       # Clients of the DRb service will get an {IbClientAdapter} object to interact with the IB api
       # @return [void]
       def start
-        DRb.start_service("druby://#{drb_host}:#{drb_port}", ib_client_adapter, verbose: true)
+        DRb.start_service("druby://#{drb_host}:#{drb_port}", ib_client_adapter, verbose: @verbose_server)
         start_ib_message_processing_thread
         puts "Ib proxy server started at druby://#{drb_host}:#{drb_port}. Connected to IB at"\
              " #{ib_host}:#{ib_port}"


### PR DESCRIPTION
With verbosity set to true, the log is very noisy when disconnecting a client from the server. Disabling server verbosity in production may prove preferable.